### PR TITLE
4.1 support

### DIFF
--- a/GraphQL/WebHookMutation.php
+++ b/GraphQL/WebHookMutation.php
@@ -13,7 +13,7 @@
 
 namespace Plugin\GMC\GraphQL;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Eccube\Common\EccubeConfig;
 use GraphQL\Type\Definition\Type;
 use Plugin\Api\Entity\WebHook;
@@ -28,7 +28,7 @@ class WebHookMutation implements Mutation
     private $webHookRepository;
 
     /**
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     private $entityManager;
 
@@ -40,7 +40,7 @@ class WebHookMutation implements Mutation
     /**
      * WebHookMutation constructor.
      */
-    public function __construct(WebHookRepository $webHookRepository, EntityManager $entityManager, EccubeConfig $eccubeConfig)
+    public function __construct(WebHookRepository $webHookRepository, EntityManagerInterface $entityManager, EccubeConfig $eccubeConfig)
     {
         $this->webHookRepository = $webHookRepository;
         $this->entityManager = $entityManager;

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -1,2 +1,9 @@
 parameters:
   gmc_proxy_url: 'https://gmc-proxy.ec-cube.net'
+services:
+  Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\ClientManager:
+    arguments:
+      - '@doctrine.orm.entity_manager'
+  Trikoder\Bundle\OAuth2Bundle\Manager\ClientManagerInterface:
+    alias: 'Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\ClientManager'
+    public: true

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,11 @@
 {
-  "name": "ec-cube/GMC",
+  "name": "ec-cube/gmc",
   "version": "1.0.3",
   "description": "Google Merchant Center",
   "type": "eccube-plugin",
   "require": {
-    "ec-cube/plugin-installer": "~0.0.7",
-    "ec-cube/Api": "~1.0"
+    "ec-cube/plugin-installer": "~0.0.7 || ^2.0",
+    "ec-cube/api": "^2.1"
   },
   "extra": {
     "code": "GMC"

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "ec-cube/gmc",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Google Merchant Center",
   "type": "eccube-plugin",
   "require": {


### PR DESCRIPTION
- `Trikoder\Bundle\OAuth2Bundle\Manager\ClientManagerInterface` を public に設定
- EntityManagerInterface を使用するよう修正
- composer2 対応
- バージョン番号変更