### PR TITLE
4.1対応でgmc/apiプラグインのアップデートに失敗する不具合の修正

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,11 @@
 {
   "name": "ec-cube/gmc",
-  "version": "1.1.0",
+  "version": "1.1.3",
   "description": "Google Merchant Center",
   "type": "eccube-plugin",
   "require": {
     "ec-cube/plugin-installer": "~0.0.7 || ^2.0",
-    "ec-cube/api": "^2.1"
+    "ec-cube/api": "~1.0 || ~2.1"
   },
   "extra": {
     "code": "GMC"


### PR DESCRIPTION
#5 の対応