### PR TITLE
SiteKitプラグインとルーティングが重複する問題の修正

### DIFF
--- a/Controller/SiteVerificationController.php
+++ b/Controller/SiteVerificationController.php
@@ -20,12 +20,9 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class SiteVerificationController extends AbstractController
 {
-    /**
-     * @Route("/google{code}.html", name="gmc_site_verification")
-     */
-    public function verifyUrl(string $code)
+    public function verifyUrl()
     {
-        $verificationFile = $this->eccubeConfig['plugin_data_realdir']."/GMC/google${code}.html";
+        $verificationFile = $this->eccubeConfig['plugin_data_realdir']."/GMC/google-site-verification.txt";
         if (file_exists($verificationFile)) {
             return new BinaryFileResponse($verificationFile);
         }

--- a/PluginManager.php
+++ b/PluginManager.php
@@ -16,6 +16,7 @@ namespace Plugin\GMC;
 use Eccube\Common\EccubeConfig;
 use Eccube\Plugin\AbstractPluginManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Filesystem\Filesystem;
 use Trikoder\Bundle\OAuth2Bundle\Manager\ClientManagerInterface;
 use Trikoder\Bundle\OAuth2Bundle\Model\Client;
 use Trikoder\Bundle\OAuth2Bundle\Model\Grant;
@@ -45,5 +46,20 @@ class PluginManager extends AbstractPluginManager
         /** @var EccubeConfig $eccubeConfig */
         $eccubeConfig = $container->get(EccubeConfig::class);
         @mkdir($eccubeConfig->get('plugin_data_realdir').'/GMC');
+
+        $fs = new Filesystem();
+        $routeYaml = $container->getParameter('plugin_data_realdir').'/GMC/routes.yaml';
+        if (!$fs->exists($routeYaml)) {
+            $fs->dumpFile($routeYaml, '');
+        }
+    }
+
+    public function update(array $meta, ContainerInterface $container)
+    {
+        $fs = new Filesystem();
+        $routeYaml = $container->getParameter('plugin_data_realdir').'/GMC/routes.yaml';
+        if (!$fs->exists($routeYaml)) {
+            $fs->dumpFile($routeYaml, '');
+        }
     }
 }

--- a/Resource/config/routes.yaml
+++ b/Resource/config/routes.yaml
@@ -1,0 +1,3 @@
+site_kit_routes:
+  resource: '../../../../PluginData/GMC/routes.yaml'
+  prefix: /

--- a/Tests/GraphQL/SiteVerifyMutationTest.php
+++ b/Tests/GraphQL/SiteVerifyMutationTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\GMC\Tests\GraphQL;
+
+
+use Eccube\Tests\EccubeTestCase;
+use Plugin\GMC\GraphQL\SiteVerifyMutation;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Yaml\Yaml;
+
+class SiteVerifyMutationTest extends EccubeTestCase
+{
+    private $verificationFile;
+    private $routeFile;
+    private $fs;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->verificationFile = $this->eccubeConfig['plugin_data_realdir'] . '/GMC/google-site-verification.txt';
+        $this->routeFile = $this->eccubeConfig['plugin_data_realdir'] . '/GMC/routes.yaml';
+
+        $this->fs = new Filesystem();
+        $this->fs->remove($this->verificationFile);
+        $this->fs->dumpFile($this->routeFile, '');
+    }
+
+    public function tearDown()
+    {
+        $this->fs->remove($this->verificationFile);
+        $this->fs->dumpFile($this->routeFile, '');
+
+        parent::tearDown();
+    }
+
+    public function testSaveToken()
+    {
+        $token = 'google9hd23l8fmpwee7f7.html';
+
+        $root = '';
+        $args = ['token' => $token];
+
+        $mutation = new SiteVerifyMutation($this->eccubeConfig);
+        $mutation->saveToken($root, $args);
+
+        self::assertTrue($this->fs->exists($this->verificationFile));
+        $actualToken = file_get_contents($this->verificationFile);
+        $actualToken = str_replace('google-site-verification: ', '', $actualToken);
+        self::assertSame($token, $actualToken);
+
+        $route = Yaml::parse(file_get_contents($this->routeFile));
+        self::assertSame([
+            'gmc_site_verification' => [
+                'path' => '/'.$token,
+                'controller' => 'Plugin\GMC\Controller\SiteVerificationController::verifyUrl'
+            ]
+        ], $route);
+    }
+}

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+$loader = require __DIR__.'/../../../../vendor/autoload.php';
+
+$envFile = __DIR__.'/../../../../.env';
+if (file_exists($envFile)) {
+    (new \Symfony\Component\Dotenv\Dotenv())->load($envFile);
+}


### PR DESCRIPTION
SiteKitプラグインとルーティングが重複する問題の修正

- キャッシュの削除で後続のAPI通信時にシステムエラーが発生するため、ルーティングの削除のみ行ってます。
https://github.com/EC-CUBE/gmc-plugin/pull/7/files#diff-03d5e6094bd6013920b37f9255c028880af1ab37d3697598a56222430a4528f2R72
- テスト追加しています(GitHubActionは未対応)