### PR TITLE
4.1でサイト認証ができない不具合を修正

### DIFF
--- a/GraphQL/SiteVerifyMutation.php
+++ b/GraphQL/SiteVerifyMutation.php
@@ -81,6 +81,12 @@ class SiteVerifyMutation implements Mutation
             $cacheDir = $this->eccubeConfig->get('kernel.cache_dir');
             $fs = new Filesystem();
             $fs->remove([
+                // 4.1
+                $cacheDir.'/UrlGenerator.php',
+                $cacheDir.'/UrlGenerator.php.meta',
+                $cacheDir.'/UrlMatcher.php',
+                $cacheDir.'/UrlMatcher.php.meta',
+                // 4.0
                 $cacheDir.'/EccubeProdProjectContainerUrlGenerator.php',
                 $cacheDir.'/EccubeProdProjectContainerUrlGenerator.php.meta',
                 $cacheDir.'/EccubeProdProjectContainerUrlMatcher.php',


### PR DESCRIPTION
4.1でルーティングのキャシュファイル名が変更されており、サイト認証のルーティングが反映されなかったので修正